### PR TITLE
Add support for protein sequences

### DIFF
--- a/crazydoc/Observers.py
+++ b/crazydoc/Observers.py
@@ -4,7 +4,7 @@ from .biotools import sequence_to_record, sequence_to_annotated_record
 class StyleObserver:
     """Generic class for observing style-based annotations in sequences.
 
-    The subclasses observe each one particular type of DNA sequence annotation
+    The subclasses observe each one particular type of sequence annotation
     such as the highlight color, bold text, underlines, etc.
 
     """
@@ -38,12 +38,13 @@ class StyleObserver:
                 features.append([value, text])
         return features
 
-    def msword_runs_to_record(self, runs):
+    def msword_runs_to_record(self, runs, is_protein=False):
         feature_records = [
             (
-                sequence_to_annotated_record(text, **{self.name: val})
+                sequence_to_annotated_record(text, is_protein=is_protein,
+                                             **{self.name: val})
                 if val
-                else sequence_to_record(text)
+                else sequence_to_record(text, is_protein=is_protein)
             )
             for (val, text) in self.aggregate_features_from_runs(runs)
         ]

--- a/crazydoc/__init__.py
+++ b/crazydoc/__init__.py
@@ -6,5 +6,5 @@ from .conf import conf
 from .Observers import StyleObserver
 from .CrazydocParser import CrazydocParser
 from .plots import CrazydocSketcher
-from .biotools import records_to_genbank
+from .biotools import records_to_genbank, records_to_fasta
 from .version import __version__

--- a/crazydoc/biotools.py
+++ b/crazydoc/biotools.py
@@ -81,15 +81,18 @@ def records_to_genbank(records, path='.', extension=None, is_protein=False):
         if name in name_duplicates:
             name_duplicates[name] += 1
             name = "%s_%03d" % (name, name_duplicates[name])
-        record = deepcopy(record)
-        record.name = record.name[:20]
-        SeqIO.write(record, os.path.join(path, name + extension), 'genbank')
+        out_record = deepcopy(record)
+        out_record.name = record.name[:20]
+        SeqIO.write(out_record, os.path.join(path, name+extension), 'genbank')
 
 def records_to_fasta(records, filename):
     name_duplicates = {}
+    out_records = []
     for record in records:
         name = record.id
+        out_record = deepcopy(record)
         if name in name_duplicates:
             name_duplicates[name] += 1
-            record.id = "%s_%03d" % (name, name_duplicates[name])
-    SeqIO.write(records, filename, 'fasta')
+            out_record.id = "%s_%03d" % (name, name_duplicates[name])
+        out_records.append(out_record)
+    SeqIO.write(out_records, filename, 'fasta')

--- a/crazydoc/biotools.py
+++ b/crazydoc/biotools.py
@@ -1,9 +1,10 @@
 import os
 
+from copy import deepcopy
 from Bio.Seq import Seq
 from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import DNAAlphabet
+from Bio.Alphabet import generic_dna, generic_protein
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 
 
@@ -41,29 +42,54 @@ def annotate_record(seqrecord, location="full", feature_type="misc_feature",
         )
     )
 
-def sequence_to_record(sequence, id='<unknown id>', name='<unknown name>'):
+def sequence_to_record(sequence, id='<unknown id>',
+                       name='<unknown name>',
+                       is_protein=False):
     """Return a SeqRecord of the sequence, ready to be Genbanked."""
-    return SeqRecord(Seq(sequence, alphabet=DNAAlphabet()), id=id, name=name)
+    alph = generic_protein if is_protein else generic_dna
+    return SeqRecord(Seq(sequence, alphabet=alph), id=id, name=name)
 
 def sequence_to_annotated_record(sequence, id='<unknown id>',
                                  name='<unknown name>',
                                  feature_type='misc_feature',
+                                 is_protein=False,
                                  **qualifiers):
-    record = sequence_to_record(sequence)
+    record = sequence_to_record(sequence, is_protein=is_protein)
     annotate_record(record, feature_type=feature_type, **qualifiers)
     return record
 
 genetic_code = 'ABCDGHKMNRSTVWY'
 nucleotides_set = set(genetic_code + genetic_code.lower())
+protein_code = 'ACDEFGHIKLMNPQRSTVWYX'
+aminoacids_set = set(protein_code + protein_code.lower())
 
-def string_is_sequence(string):
-    return len(string) and (set(string) <= nucleotides_set)
+def string_is_sequence(string, is_protein=False):
+    if is_protein:
+        return len(string) and (set(string) <= aminoacids_set)
+    else:
+        return len(string) and (set(string) <= nucleotides_set)
 
-def records_to_genbank(records, path='.', extension='.gbk'):
+def records_to_genbank(records, path='.', extension=None, is_protein=False):
+    if not extension:
+        if is_protein:
+            extension = '.gp'
+        else:
+            extension = '.gbk'
+    name_duplicates = {}
+    for record in records:
+        name = record.id.replace('/', '-')
+        if name in name_duplicates:
+            name_duplicates[name] += 1
+            name = "%s_%03d" % (name, name_duplicates[name])
+        record = deepcopy(record)
+        record.name = record.name[:20]
+        SeqIO.write(record, os.path.join(path, name + extension), 'genbank')
+
+def records_to_fasta(records, filename):
     name_duplicates = {}
     for record in records:
         name = record.id
         if name in name_duplicates:
             name_duplicates[name] += 1
-            name = "%s_%03d" % (name, name_duplicates[name])
-        SeqIO.write(record, os.path.join(path, name + extension), 'genbank')
+            record.id = "%s_%03d" % (name, name_duplicates[name])
+    SeqIO.write(records, filename, 'fasta')


### PR DESCRIPTION
- Add support for protein sequences (with argument `is_protein=True` passed to `CrazydocParser.parse_doc_file` and `biotools.records_to_genbank`)
- add FASTA export option (to one file only, no annotations; could be complemented by a TSV annotation export)
- fix genbank name (remove `/` since it's used as filename; clip to stay under 20 chars for LOCUS line)